### PR TITLE
feat: added option to set neovim as default editor

### DIFF
--- a/nixneovim.nix
+++ b/nixneovim.nix
@@ -157,8 +157,6 @@ in
         plugins = cfg.extraPlugins;
       };
 
-      environment.variables.EDITOR = mkIf cfg.defaultEditor (mkOverride 900 "nvim");
-
       extraWrapperArgs = optionalString (cfg.extraPackages != [ ])
         ''--prefix PATH : "${makeBinPath cfg.extraPackages}"'';
 

--- a/nixneovim.nix
+++ b/nixneovim.nix
@@ -37,6 +37,12 @@ in
     programs.nixneovim = {
       enable = mkEnableOption "enable nixneovim";
 
+      defaultEditor = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Configures neovim to be the default editor using the EDITOR environment variable.";
+      };
+
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
@@ -151,6 +157,8 @@ in
         plugins = cfg.extraPlugins;
       };
 
+      environment.variables.EDITOR = mkIf cfg.defaultEditor (mkOverride 900 "nvim");
+
       extraWrapperArgs = optionalString (cfg.extraPackages != [ ])
         ''--prefix PATH : "${makeBinPath cfg.extraPackages}"'';
 
@@ -238,6 +246,7 @@ in
         {
           programs.neovim = {
             enable = true;
+            defaultEditor = cfg.defaultEditor;
             package = mkIf (cfg.package != null) cfg.package;
             extraPackages = cfg.extraPackages;
             extraConfig = configure.customRC;

--- a/nixneovim.nix
+++ b/nixneovim.nix
@@ -255,6 +255,7 @@ in
         {
           environment.systemPackages = [ wrappedNeovim ];
           programs.neovim = {
+            defaultEditor = cfg.defaultEditor;
             configure = configure;
           };
 


### PR DESCRIPTION
Noticed that the `defaultEditor` option was missing. 