### PR TITLE
Fix cmp copilot

### DIFF
--- a/plugins/completion/nvim-cmp/options/sources.nix
+++ b/plugins/completion/nvim-cmp/options/sources.nix
@@ -52,7 +52,7 @@ let
     cmp_pandoc = { packages = [ cmp-pandoc-nvim ]; };
     cmp_tabnine = { packages = [ cmp-tabnine ]; };
     conventionalcommits = { packages = [ cmp-conventionalcommits ]; };
-    copilot = { };
+    copilot = { packages = [ ]; };
     crates = { packages = [ crates-nvim ]; extraConfig = "require('crates').setup()"; };
     dap = { packages = [ cmp-dap ]; };
     dictionary = { packages = [ cmp-dictionary ]; };

--- a/plugins/completion/nvim-cmp/options/sources.nix
+++ b/plugins/completion/nvim-cmp/options/sources.nix
@@ -52,7 +52,7 @@ let
     cmp_pandoc = { packages = [ cmp-pandoc-nvim ]; };
     cmp_tabnine = { packages = [ cmp-tabnine ]; };
     conventionalcommits = { packages = [ cmp-conventionalcommits ]; };
-    copilot = { packages = [ cmp-copilot ]; };
+    copilot = { };
     crates = { packages = [ crates-nvim ]; extraConfig = "require('crates').setup()"; };
     dap = { packages = [ cmp-dap ]; };
     dictionary = { packages = [ cmp-dictionary ]; };


### PR DESCRIPTION
The `copilot` source can be provided by either [cmp-copilot](https://github.com/hrsh7th/cmp-copilot) or [copilot-cmp](https://github.com/zbirenbaum/copilot-cmp), and the cmp source names are exactly identical. So unfortunately I don't think you can automatically put the package name here; instead someone will have to install and configure the correct package.