### PR TITLE
add sources filter

### DIFF
--- a/plugins/completion/nvim-cmp/options/sources.nix
+++ b/plugins/completion/nvim-cmp/options/sources.nix
@@ -23,6 +23,10 @@ let
         options = {
           enable = mkEnableOption "";
           priority = intNullOption "";
+          entryFilter = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+          };
           option = mkOption {
             type = nullOr (attrsOf anything);
             description = "If direct lua code is needed use helpers.mkRaw";


### PR DESCRIPTION
Allows the removal of a bunch of annoying `cmp` objects using the following filter:

```
entry_filter = function(entry, ctx)
  return require('cmp.types').lsp.CompletionItemKind[entry:get_kind()] ~= 'Text'
end
```