### PR TITLE
Fix CMP snippet function

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -231,7 +231,7 @@ with helpers;
         sources = sources.config;
 
         snippet = {
-          expand = "function(args) ${ lib.optionalString cfg.snippet.luasnip.enable "require(\"luasnip\").lsp_expand(args.body)" } end";
+          expand.__raw = "function(args) ${ lib.optionalString cfg.snippet.luasnip.enable "require(\"luasnip\").lsp_expand(args.body)" } end";
         };
 
         view = cfg.view;


### PR DESCRIPTION
This gets coerced to a string, which is wrong; it should be raw lua for CMP to work properly.