### PR TITLE
fix: split modified to improve compatibility with aarch64-darwin systems

### DIFF
--- a/helper/to_lua/default.nix
+++ b/helper/to_lua/default.nix
@@ -15,8 +15,8 @@ let
       isChar  = x:
         elem x lowerCaseLetters || elem x upperCaseLetters;
 
-      upperCaseLetters = split "" "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-      lowerCaseLetters = split "" "abcdefghijklmnopqrstuvwxyz";
+      upperCaseLetters = split "," "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z";
+      lowerCaseLetters = split "," "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z";
 
       isUpper = x: elem x upperCaseLetters; # check if x is uppercase
 

--- a/helper/to_lua/default.nix
+++ b/helper/to_lua/default.nix
@@ -6,7 +6,7 @@ let
     stringAsChars
     stringToCharacters
     toLower;
-  inherit (builtins) head split;
+  inherit (builtins) head;
 
   # takes camalCase string and converts it to snake_case
   camelToSnake = string:
@@ -15,8 +15,8 @@ let
       isChar  = x:
         elem x lowerCaseLetters || elem x upperCaseLetters;
 
-      upperCaseLetters = split "," "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z";
-      lowerCaseLetters = split "," "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z";
+      upperCaseLetters = [ "A" "B" "C" "D" "E" "F" "G" "H" "I" "J" "K" "L" "M" "N" "O" "P" "Q" "R" "S" "T" "U" "V" "W" "X" "Y" "Z" ];
+      lowerCaseLetters = [ "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" ];
 
       isUpper = x: elem x upperCaseLetters; # check if x is uppercase
 


### PR DESCRIPTION
I decided to try the module on my m1 Mac and got an error while building the flake that the regular expression was invalid

```shell
error: invalid regular expression ''

       at /nix/store/gg1l117a7fx1334n57zhxcb0mg7ndj4c-source/helper/to_lua/default.nix:18:26:

           17|
           18|       upperCaseLetters = split "" "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
             |                          ^
           19|       lowerCaseLetters = split "" "abcdefghijklmnopqrstuvwxyz";
```

I launched `nix repl` on the m1 tried the split manually on the m1 and got the same error
```shell
nix-repl> builtins.split "" "ABCDEFGHIJKLMNOPQRSTUVWXYZ"                          
error: invalid regular expression ''

       at «string»:1:1:

            1| builtins.split "" "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
             | ^
```
However, on my "x86_64-linux" machine, the original function worked fine
```shell
nix-repl> builtins.split "" "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
[ "" [ ... ] "A" [ ... ] "B" [ ... ] "C" [ ... ] "D" [ ... ] "E" [ ... ] "F" [ ... ] "G" [ ... ] "H" [ ... ] "I" [ ... ] "J" [ ... ] "K" [ ... ] "L" [ ... ] "M" [ ... ] "N" [ ... ] "O" [ ... ] "P" [ ... ] "Q" [ ... ] "R" [ ... ] "S" [ ... ] "T" [ ... ] "U" [ ... ] "V" [ ... ] "W" [ ... ] "X" [ ... ] "Y" [ ... ] "Z" [ ... ] "" ]
```

I opted to do a comma-separated list. Although its not as pretty it works on both machines
```shell
nix-repl> builtins.split "," "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z"
[ "A" [ ... ] "B" [ ... ] "C" [ ... ] "D" [ ... ] "E" [ ... ] "F" [ ... ] "G" [ ... ] "H" [ ... ] "I" [ ... ] "J" [ ... ] "K" [ ... ] "L" [ ... ] "M" [ ... ] "N" [ ... ] "O" [ ... ] "P" [ ... ] "Q" [ ... ] "R" [ ... ] "S" [ ... ] "T" [ ... ] "U" [ ... ] "V" [ ... ] "W" [ ... ] "X" [ ... ] "Y" [ ... ] "Z" ]
```