### PR TITLE
fix(lsp): onAttach not doing anything

### DIFF
--- a/plugins/nvim-lsp/default.nix
+++ b/plugins/nvim-lsp/default.nix
@@ -17,7 +17,7 @@ let
 
     onAttach = mkOption {
       type = types.lines;
-      description = "A lua function to be run when a new LSP buffer is attached. The argument `client` is provided.";
+      description = "A lua function to be run when a new LSP buffer is attached. The argument `client` and `bufnr` is provided.";
       default = "";
     };
 

--- a/plugins/nvim-lsp/lsp-helpers.nix
+++ b/plugins/nvim-lsp/lsp-helpers.nix
@@ -26,8 +26,15 @@ let
     in
     ''
       do -- lsp server config ${server}
-        local __on_attach = function(client, bufnr)
+        local __on_attach_base = function(client, bufnr)
+          ${cfg.servers.onAttach}
+        end
+        local __on_attach_extra = function(client, bufnr)
           ${cfg.servers.${server}.onAttachExtra}
+        end
+        local __on_attach = function(client, bufnr)
+	  __on_attach_base(client, bufnr)
+	  __on_attach_extra(client, bufnr)
         end
         ${setup}
         require('lspconfig')["${serverName}"].setup(__setup)


### PR DESCRIPTION
`lsp.onAttach` was not being used, only
`lsp.servers.${server}.onAttachExtra` was being applied, this commit fixes that.

It also fixes `lsp.onAttach` documentation to also state that `bufnr` is provided, to be consistent with `onAttachExtra`