### PR TITLE
feat: use real lspsaga plugin

### DIFF
--- a/plugins/utils/lspsaga.nix
+++ b/plugins/utils/lspsaga.nix
@@ -1,225 +1,126 @@
 { pkgs, lib, config, ... }:
-with lib;
 let
-  cfg = config.programs.nixneovim.plugins.lspsaga;
+  name = "lspsaga";
+  pluginUrl = "https://github.com/nvimdev/lspsaga.nvim";
+  
   helpers = import ../../helper { inherit pkgs lib config; };
-  inherit (helpers.customOptions) boolOption intOption;
-in
-with helpers;
-{
-  options = {
-    programs.nixneovim.plugins.lspsaga = {
-      enable = mkEnableOption "Enable lspsaga.nvim";
+  inherit (helpers.customOptions)
+    strOption
+    intOption
+    boolOption
+    listOption;
+  cfg = config.programs.nixneovim.plugins.${name};
 
-      signs = {
-        use = mkOption {
-          default = true;
-          type = types.bool;
-          description = "Whether to use diagnostic signs";
-        };
-
-        error = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Error diagnostic sign";
-        };
-
-        warning = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Warning diagnostic sign";
-        };
-
-        hint = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Hint diagnostic sign";
-        };
-
-        info = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Info diagnostic sign";
-        };
+  moduleOptions = {
+    hover = {
+      openLink = strOption "gx" "";
+      openBrowser = strOption "!chrome" "";
+    };
+    diagnostic = {
+      showCodeAction = boolOption true "It will show available actions in the diagnsotic jump window.";
+      showSource = boolOption true "Extend source into the diagnostic message.";
+      jumpNumShortcut = boolOption true "After jumping, Lspasga will automatically bind code actions to a number. Afterwards, you can press the number to execute the code action. After the floating window is closed, these numbers will no longer be tied to the same code actions.";
+      keys = {
+        execAction = strOption "o" "";
+        quit = strOption "q" "";
+        expandOrJump = strOption "<CR>" "";
+        quitInShow = listOption [
+          "q"
+            "<ESC>"
+        ] "";
       };
-
-      headers = {
-        error = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Error diagnostic header";
-        };
-
-        warning = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Warning diagnostic header";
-        };
-
-        hint = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Hint diagnostic header";
-        };
-
-        info = mkOption {
-          type = types.nullOr types.str;
-          default = "  Info";
-          description = "Info diagnostic header";
-        };
+    };
+    codeAction = {
+      numShortcut = boolOption true "";
+      extendGitsigns = boolOption false "";
+      keys = {
+        quit = strOption "q" "";
+        exec = strOption "<CR>" "";
       };
-
-      maxDialogWidth = mkOption {
-        type = types.nullOr types.int;
-        default = null;
-        description = "Maximum dialog width";
+    };
+    lightbulb = {
+      enable = boolOption true "";
+      enableInInsert = boolOption true "";
+      sign = boolOption true "";
+      virtualText = boolOption true "";
+    };
+    preview = {
+      linesAbove = intOption 0 "";
+      linesBelow = intOption 10 "";
+    };
+    scrollPreview = {
+      scrollDown = strOption "<C-f>" "";
+      scrollUp = strOption "<C-b>" "";
+    };
+    requestTimeout = intOption 2000 "";
+    finder = {
+      keys = {
+        jumpTo = strOption "p" "Finder peek window.";
+        expandOrJump = strOption "o" "";
+        vsplit = strOption "s" "";
+        split = strOption "i" "";
+        tabe = strOption "t" "";
+        tabnew = strOption "r" "";
+        quit = listOption [
+          "q"
+            "<ESC>"
+        ] "";
+        closeInPreview = strOption "<ESC>" "";
       };
-
-      icons = {
-        codeAction = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Code action icon";
-        };
-
-        findDefinition = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Find definition icon";
-        };
-
-        findReference = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Find reference icon";
-        };
-
-        definitionPreview = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Definition preview icon";
-        };
+    };
+    definition = {
+      edit = strOption "<C-c>o" "";
+      vsplit = strOption "<C-c>v" "";
+      split = strOption "<C-c>i" "";
+      tabe = strOption "<C-c>t" "";
+      quit = strOption "q" "";
+    };
+    rename = {
+      quit = strOption "<C-c>" "";
+      exec = strOption "<CR>" "";
+      inSelect = boolOption true "";
+    };
+    symbolInWinbar = {
+      enable = boolOption true "";
+      separator = strOption " " "";
+      showFile = boolOption true "";
+      colorMode = boolOption true "";
+    };
+    outline = {
+      winPosition = strOption "right" "";
+      autoPreview = boolOption true "";
+      autoRefresh = boolOption true "";
+      autoClose = boolOption true "";
+      autoResize = boolOption false "";
+      closeAfterJump = boolOption false "";
+      keys = {
+        expandOrJump = strOption "o" "";
+        quit = strOption "q" "";
       };
-
-      maxFinderPreviewLines = mkOption {
-        type = types.nullOr types.int;
-        default = null;
-        description = "Maximum finder preview lines";
+    };
+    callhierarchy = {
+      showDetail = boolOption false "";
+      keys = {
+        edit = strOption "e" "";
+        vsplit = strOption "s" "";
+        split = strOption "i" "";
+        tabe = strOption "t" "";
+        jump = strOption "o" "";
+        quit = strOption "q" "";
+        expandCollapse = strOption "u" "";
       };
-
-      keys =
-        let
-          defaultKeyOpt = desc: mkOption {
-            description = desc;
-            type = types.nullOr types.str;
-            default = null;
-          };
-        in
-        {
-          finderAction = {
-            open = defaultKeyOpt "Open from finder";
-            vsplit = defaultKeyOpt "Vertical split in finder";
-            split = defaultKeyOpt "Horizontal split in finder";
-            quit = defaultKeyOpt "Quit finder";
-            scrollDown = defaultKeyOpt "Scroll down finder";
-            scrollUp = defaultKeyOpt "Scroll up finder";
-          };
-
-          codeAction = {
-            quit = defaultKeyOpt "Quit code actions menu";
-            exec = defaultKeyOpt "Execute code action";
-          };
-        };
-
-      codeActionPrompt = {
-        enable = boolOption true "Enable code_action_prompt";
-        sign = boolOption true "Display sign";
-        enableInInsert = boolOption true "Enable prompt in inset mode";
-        signPriority = intOption 20 "Priority of prompt (?)";
-        virtualText = boolOption true "Use neovims virtual text feature";
-      };
-
-      borderStyle = mkOption {
-        type = types.nullOr (types.enum [ "single" "round" "plus" "double" "bold" ]);
-        default = null;
-        description = "Border style";
-      };
-
-      renamePromptPrefix = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        description = "Rename prompt prefix";
-      };
+    };
+    beacon = {
+      enable = boolOption true "";
+      frequency = intOption 7 "";
     };
   };
 
-  config.programs.nixneovim =
-    let
-      notDefault = default: opt: if (opt != default) then opt else null;
-      notEmpty = opt: if ((filterAttrs (_: v: v != null) opt) != { }) then opt else null;
-      notNull = opt: opt;
-      lspsagaConfig = {
-        use_saga_diagnostic_sign = notDefault true cfg.signs.use;
-        error_sign = notNull cfg.signs.error;
-        warn_sign = notNull cfg.signs.warning;
-        hint_sign = notNull cfg.signs.hint;
-        infor_sign = notNull cfg.signs.info;
-
-        # TODO Fix this!
-        # error_header = notNull cfg.headers.error;
-        # warn_header = notNull cfg.headers.warning;
-        # hint_header = notNull cfg.headers.hint;
-        # infor_header = notNull cfg.headers.info;
-
-        max_diag_msg_width = notNull cfg.maxDialogWidth;
-
-        code_action_icon = notNull cfg.icons.codeAction;
-        finder_definition_icon = notNull cfg.icons.findDefinition;
-        finder_reference_icon = notNull cfg.icons.findReference;
-        definition_preview_icon = notNull cfg.icons.definitionPreview;
-
-        max_finder_preview_lines = notNull cfg.maxFinderPreviewLines;
-
-        rename_prompt_prefix = notNull cfg.renamePromptPrefix;
-
-        border_style = cfg.borderStyle;
-
-        code_action_prompt = notEmpty {
-          enable = notNull cfg.codeActionPrompt.enable;
-          sign = notNull cfg.codeActionPrompt.sign;
-          enable_in_insert = notNull cfg.codeActionPrompt.enableInInsert;
-          sign_priority = notNull cfg.codeActionPrompt.signPriority;
-          virtual_text = notNull cfg.codeActionPrompt.virtualText;
-        };
-
-        finder_action_keys =
-          let
-            keys = {
-              open = notNull cfg.keys.finderAction.open;
-              vsplit = notNull cfg.keys.finderAction.vsplit;
-              split = notNull cfg.keys.finderAction.split;
-              quit = notNull cfg.keys.finderAction.quit;
-              scroll_down = notNull cfg.keys.finderAction.scrollDown;
-              scroll_up = notNull cfg.keys.finderAction.scrollUp;
-            };
-          in
-          notEmpty keys;
-
-        code_action_keys =
-          let
-            keys = {
-              quit = notNull cfg.keys.codeAction.quit;
-              exec = notNull cfg.keys.codeAction.exec;
-            };
-          in
-          notEmpty keys;
-      };
-    in
-    mkIf cfg.enable {
-      extraPlugins = [ pkgs.vimPlugins.lspsaga-nvim ];
-
-      extraConfigLua = ''
-        require("lspsaga").init_lsp_saga(${helpers.toLuaObject lspsagaConfig})
-      '';
-    };
+  pluginOptions = helpers.convertModuleOptions cfg moduleOptions;
+in
+with helpers;
+mkLuaPlugin {
+  inherit name moduleOptions pluginUrl;
+  extraPlugins = with pkgs.vimExtraPlugins; [ lspsaga-nvim ];
+  defaultRequire = true;
 }


### PR DESCRIPTION
The lspsaga module was still using the old "api"; so not `mkLuaPlugin`. More importantly, it was using the weird fork of lspsaga that is in `nixpkgs`, which claims to be maintained although it isn't. In contrary, the "real" lspsaga plugin is still maintained and has gotten a ton of new features since this fork.

This PR updates the module to use the real plugin and the `mkLuaPlugin`-api. Since the options of lspsaga totally changed in newer versions, this may break some configurations. Nevertheless, I think it is quite important to do this switch to the real plugin.