### PR TITLE
fix(flake.nix): Follow nixpkgs in inputs.home-manager and nixneovimplugins

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,7 +33,9 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1685885003,
@@ -68,7 +70,9 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1686145424,
@@ -85,38 +89,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1659190188,
-        "narHash": "sha256-LudYrDFPFaQMW0l68TYkPWRPKmqpxIFU1nWfylIp9AQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a3fddd46a7f3418d7e3940ded94701aba569161d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1685836261,
         "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
@@ -169,7 +141,7 @@
         "home-manager": "home-manager",
         "nix-flake-tests": "nix-flake-tests",
         "nixneovimplugins": "nixneovimplugins",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "nmd": "nmd",
         "nmt": "nmt"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,12 @@
     };
 
     nixneovimplugins.url = "github:nixneovim/nixneovimplugins";
-    nix-flake-tests.url = "github:antifuchs/nix-flake-tests";
+    nixneovimplugins.inputs.nixpkgs.follows = "nixpkgs";
+
     home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-flake-tests.url = "github:antifuchs/nix-flake-tests";
   };
 
   outputs = { self, nixpkgs, nmd, nmt, nix-flake-tests, ... }@inputs:


### PR DESCRIPTION
This prevents the nixpkgs from home-manager and nixneovimplugins from being out of date with NixNeovim's nixpkgs, and makes it easier to override for the user.

The home-manager documentation recommends it:
https://nix-community.github.io/home-manager/index.html#sec-flakes-nixos-module

It also appears in the Flakes documentation for NixOS: https://nixos.wiki/wiki/Flakes#Input_schema

> The `follows` keyword in inputs is used for inheritance.
> Here, `inputs.nixpkgs` of sops-nix is kept consistent with the `inputs.nixpkgs` of
> the current flake, to avoid problems caused by different versions of nixpkgs.