### PR TITLE
fix(flake.nix): Switch nmd repo to SourceHut

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,17 +107,17 @@
     "nmd": {
       "flake": false,
       "locked": {
-        "lastModified": 1680213367,
-        "narHash": "sha256-NbSXxpFAK5IMcsQTK0vSGy099HExx3SEagqW4Lpc+X8=",
-        "owner": "rycee",
+        "lastModified": 1683614069,
+        "narHash": "sha256-iq5HgZyr5oStuu6sj5xQkYiBRfFvyyfPBYDKwjklPcY=",
+        "owner": "~rycee",
         "repo": "nmd",
-        "rev": "abb15317ebd17e5a0a7dd105e2ce52f2700185a8",
-        "type": "gitlab"
+        "rev": "07a6db31ae19d728ef1e4dc02b9687a6c359c216",
+        "type": "sourcehut"
       },
       "original": {
-        "owner": "rycee",
+        "owner": "~rycee",
         "repo": "nmd",
-        "type": "gitlab"
+        "type": "sourcehut"
       }
     },
     "nmt": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     nmd = {
-      url = "gitlab:rycee/nmd";
+      url = "sourcehut:~rycee/nmd";
       flake = false;
     };
     nmt = {


### PR DESCRIPTION
The original GitLab repo has been archived, and development is being done in SourceHut.

- [Original GitLab Repo](https://gitlab.com/rycee/nmd)
- [SourceHut Repo](https://git.sr.ht/~rycee/nmd)