### PR TITLE
fix(nix): types.string deprecated

### DIFF
--- a/plugins/utils/specs.nix
+++ b/plugins/utils/specs.nix
@@ -95,12 +95,12 @@ in
     };
 
     ignored_filetypes = mkOption {
-      type = with types; listOf string;
+      type = with types; listOf str;
       default = [ ];
     };
 
     ignored_buffertypes = mkOption {
-      type = with types; listOf string;
+      type = with types; listOf str;
       default = [ "nofile" ];
     };
 


### PR DESCRIPTION
Fixes warning when running `nix flake check`

see: https://github.com/NixOS/nixpkgs/pull/66346

Use `types.str` when merging makes no sense (ie. "Hello" "World" shouln't become "HelloWorld"), `types.separatedString "${sep}"` when merging should be done (prefer `listOf str` though), and `types.lines` for line based configuration.