### PR TITLE
fix(treewide): fix double 'Enable' with mkEnableOption

### DIFF
--- a/src/colorschemes/base16.nix
+++ b/src/colorschemes/base16.nix
@@ -7,7 +7,7 @@ in
 {
   options = {
     programs.nixneovim.colorschemes.base16 = {
-      enable = mkEnableOption "Enable base16";
+      enable = mkEnableOption "base16";
 
       useTruecolor = mkOption {
         type = types.bool;

--- a/src/colorschemes/gruvbox-nvim.nix
+++ b/src/colorschemes/gruvbox-nvim.nix
@@ -7,12 +7,12 @@ in
 {
   options = {
     programs.nixneovim.colorschemes.gruvbox-nvim = {
-      enable = mkEnableOption "Enable gruvbox-nvim";
+      enable = mkEnableOption "gruvbox-nvim";
 
-      italics = mkEnableOption "Enable italics";
-      bold = mkEnableOption "Enable bold";
-      underline = mkEnableOption "Enable underlined text";
-      undercurl = mkEnableOption "Enable undercurled text";
+      italics = mkEnableOption "italics";
+      bold = mkEnableOption "bold";
+      underline = mkEnableOption "underlined text";
+      undercurl = mkEnableOption "undercurled text";
 
       contrastDark = mkOption {
         type = types.nullOr (types.enum [ "soft" "medium" "hard" ]);
@@ -106,7 +106,7 @@ in
 
       transparentBg = mkEnableOption "Transparent background";
 
-      trueColor = mkEnableOption "Enable true color support";
+      trueColor = mkEnableOption "true color support";
 
     };
   };

--- a/src/colorschemes/nord.nix
+++ b/src/colorschemes/nord.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.colorschemes.nord = {
-      enable = mkEnableOption "Enable nord";
+      enable = mkEnableOption "nord";
 
       contrast = mkEnableOption
         "Make sidebars and popup menus like nvim-tree and telescope have a different background";

--- a/src/colorschemes/one.nix
+++ b/src/colorschemes/one.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.colorschemes.one = {
-      enable = mkEnableOption "Enable vim-one";
+      enable = mkEnableOption "vim-one";
     };
   };
 

--- a/src/colorschemes/onedark.nix
+++ b/src/colorschemes/onedark.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.colorschemes.onedark = {
-      enable = mkEnableOption "Enable onedark";
+      enable = mkEnableOption "onedark";
     };
   };
 

--- a/src/colorschemes/tokyonight.nix
+++ b/src/colorschemes/tokyonight.nix
@@ -7,7 +7,7 @@ in
 {
   options = {
     programs.nixneovim.colorschemes.tokyonight = {
-      enable = mkEnableOption "Enable tokyonight";
+      enable = mkEnableOption "tokyonight";
       style = mkOption {
         type = types.nullOr style;
         default = null;
@@ -20,7 +20,7 @@ in
       italicFunctions = mkEnableOption "Make functions italic";
       italicVariables = mkEnableOption "Make variables and identifiers italic";
       transparent =
-        mkEnableOption "Enable this to disable setting the background color";
+        mkEnableOption "this to disable setting the background color";
       hideInactiveStatusline = mkEnableOption
         "Enabling this option will hide inactive statuslines and replace them with a thin border";
       transparentSidebar = mkEnableOption

--- a/src/deprecated/packer.nix
+++ b/src/deprecated/packer.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.packer = {
-      enable = mkEnableOption "Enable packer.nvim";
+      enable = mkEnableOption "packer.nvim";
 
       plugins = mkOption {
         type = types.listOf (types.oneOf [

--- a/src/plugins/_telescope-modules/extensions.nix
+++ b/src/plugins/_telescope-modules/extensions.nix
@@ -40,7 +40,7 @@ let
       options =
         let
           defaultOptions = {
-            enable = mkEnableOption "Enable ${name}";
+            enable = mkEnableOption "${name}";
             extraConfig = mkOption {
               type = types.attrs;
               default = { };

--- a/src/plugins/_telescope-modules/frecency.nix
+++ b/src/plugins/_telescope-modules/frecency.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.telescope.extensions.frecency = {
-    enable = mkEnableOption "Enable frecency";
+    enable = mkEnableOption "frecency";
 
     dbRoot = mkOption {
       type = types.nullOr types.str;

--- a/src/plugins/_telescope-modules/fzf-native.nix
+++ b/src/plugins/_telescope-modules/fzf-native.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.telescope.extensions.fzf-native = {
-    enable = mkEnableOption "Enable fzf-native";
+    enable = mkEnableOption "fzf-native";
 
     fuzzy = mkOption {
       type = types.nullOr types.bool;

--- a/src/plugins/_telescope-modules/fzy-native.nix
+++ b/src/plugins/_telescope-modules/fzy-native.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.telescope.extensions.fzy-native = {
-    enable = mkEnableOption "Enable fzy-native";
+    enable = mkEnableOption "fzy-native";
 
     overrideGenericSorter = mkOption {
       type = types.nullOr types.bool;

--- a/src/plugins/airline.nix
+++ b/src/plugins/airline.nix
@@ -13,7 +13,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.airline = {
-      enable = mkEnableOption "Enable airline";
+      enable = mkEnableOption "airline";
 
       extensions = mkOption {
         default = null;

--- a/src/plugins/bufferline.nix
+++ b/src/plugins/bufferline.nix
@@ -24,7 +24,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.bufferline = {
-      enable = mkEnableOption "Enable bufferline";
+      enable = mkEnableOption "bufferline";
       numbers = mkOption {
         type = types.nullOr types.lines;
         description = "A lua function customizing the styling of numbers.";

--- a/src/plugins/commentary.nix
+++ b/src/plugins/commentary.nix
@@ -8,7 +8,7 @@ in
 
   options = {
     programs.nixneovim.plugins.commentary = {
-      enable = mkEnableOption "Enable commentary";
+      enable = mkEnableOption "commentary";
     };
   };
 

--- a/src/plugins/coq.nix
+++ b/src/plugins/coq.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.coq = {
-      enable = mkEnableOption "Enable coq";
+      enable = mkEnableOption "coq";
 
       installArtifacts = mkEnableOption "Install coq-artifacts";
 

--- a/src/plugins/dashboard.nix
+++ b/src/plugins/dashboard.nix
@@ -7,7 +7,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.dashboard = {
-      enable = mkEnableOption "Enable dashboard";
+      enable = mkEnableOption "dashboard";
 
       header = mkOption {
         description = "Header text";

--- a/src/plugins/easyescape.nix
+++ b/src/plugins/easyescape.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.easyescape = {
-      enable = mkEnableOption "Enable easyescape";
+      enable = mkEnableOption "easyescape";
     };
   };
   config = mkIf cfg.enable {

--- a/src/plugins/floaterm.nix
+++ b/src/plugins/floaterm.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.floaterm = {
-      enable = mkEnableOption "Enable floaterm";
+      enable = mkEnableOption "floaterm";
       shell = mkOption {
         type = types.nullOr types.str;
         default = null;

--- a/src/plugins/gitgutter.nix
+++ b/src/plugins/gitgutter.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.gitgutter = {
-      enable = mkEnableOption "Enable gitgutter";
+      enable = mkEnableOption "gitgutter";
 
       recommendedSettings = mkOption {
         type = types.bool;

--- a/src/plugins/lightline.nix
+++ b/src/plugins/lightline.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.lightline = {
-      enable = mkEnableOption "Enable lightline";
+      enable = mkEnableOption "lightline";
 
       colorscheme = mkOption {
         type = with types; nullOr str;

--- a/src/plugins/lualine.nix
+++ b/src/plugins/lualine.nix
@@ -60,7 +60,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.lualine = {
-      enable = mkEnableOption "Enable lualine";
+      enable = mkEnableOption "lualine";
 
       theme = mkOption {
         default = config.programs.nixneovim.colorscheme;

--- a/src/plugins/mark-radar.nix
+++ b/src/plugins/mark-radar.nix
@@ -7,7 +7,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.mark-radar = {
-    enable = mkEnableOption "Enable mark-radar";
+    enable = mkEnableOption "mark-radar";
 
     highlight_background = mkOption {
       type = with types; nullOr bool;

--- a/src/plugins/mini.nix
+++ b/src/plugins/mini.nix
@@ -57,7 +57,7 @@ let
   moduleOptions = mapAttrs
     (module: config:
       config // {
-        enable = mkEnableOption "Enable mini.${module}";
+        enable = mkEnableOption "mini.${module}";
         extraConfig = mkOption {
           type = types.attrs;
           default = { };

--- a/src/plugins/neogit.nix
+++ b/src/plugins/neogit.nix
@@ -23,7 +23,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.neogit = {
-      enable = mkEnableOption "Enable neogit";
+      enable = mkEnableOption "neogit";
 
       disableSigns = mkOption {
         description = "Disable signs";

--- a/src/plugins/notify.nix
+++ b/src/plugins/notify.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.notify = {
-    enable = mkEnableOption "Enable notify";
+    enable = mkEnableOption "notify";
 
     stages = mkOption {
       type = types.nullOr (types.enum [ "fade_in_slide_out" "fade" "slide" "static" ]);

--- a/src/plugins/null-ls.nix
+++ b/src/plugins/null-ls.nix
@@ -10,7 +10,7 @@ in
   ];
 
   options.programs.nixneovim.plugins.null-ls = {
-    enable = mkEnableOption "Enable null-ls";
+    enable = mkEnableOption "null-ls";
 
     debug = mkOption {
       default = null;

--- a/src/plugins/nvim-autopairs.nix
+++ b/src/plugins/nvim-autopairs.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.nvim-autopairs = {
-    enable = mkEnableOption "Enable nvim-autopairs";
+    enable = mkEnableOption "nvim-autopairs";
 
     pairs = mkOption {
       type = types.nullOr (types.attrsOf types.str);

--- a/src/plugins/nvim-cmp.nix
+++ b/src/plugins/nvim-cmp.nix
@@ -30,7 +30,7 @@ in {
 
   # FIX: rtp attribute is deprecated, use outPath instead
   options.programs.nixneovim.plugins.nvim-cmp = {
-    enable = mkEnableOption "Enable nvim-cmp";
+    enable = mkEnableOption "nvim-cmp";
 
     inherit (super.nvim-cmp-modules)
       performance

--- a/src/plugins/nvim-tree.nix
+++ b/src/plugins/nvim-tree.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.nvim-tree = {
-    enable = mkEnableOption "Enable nvim-tree";
+    enable = mkEnableOption "nvim-tree";
 
     disableNetrw = mkOption {
       type = types.nullOr types.bool;

--- a/src/plugins/specs.nix
+++ b/src/plugins/specs.nix
@@ -8,7 +8,7 @@ let
 in
 {
   options.programs.nixneovim.plugins.specs = {
-    enable = mkEnableOption "Enable specs-nvim";
+    enable = mkEnableOption "specs-nvim";
 
     show_jumps = mkOption {
       type = types.bool;

--- a/src/plugins/tabby.nix
+++ b/src/plugins/tabby.nix
@@ -27,7 +27,7 @@ let
 in {
   options = {
     programs.nixneovim.plugins.${name} = {
-      enable = mkEnableOption "Enable ${name}";
+      enable = mkEnableOption "${name}";
 
       presets = {
         activeWinsAtTall = boolOption false "";

--- a/src/plugins/telescope.nix
+++ b/src/plugins/telescope.nix
@@ -72,7 +72,7 @@ in mkLuaPlugin {
 #   # ];
 
 #   options.programs.nixneovim.plugins.telescope = {
-#     enable = mkEnableOption "Enable telescope.nvim";
+#     enable = mkEnableOption "telescope.nvim";
 
 #     # extensionConfig = mkOption {
 #     #   type = types.attrsOf types.anything;

--- a/src/plugins/trouble.nix
+++ b/src/plugins/trouble.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.trouble = {
-      enable = mkEnableOption "Enable trouble.nvim";
+      enable = mkEnableOption "trouble.nvim";
 
       position = mkOption {
         description = "position of the list";

--- a/src/plugins/undotree.nix
+++ b/src/plugins/undotree.nix
@@ -6,7 +6,7 @@ in
 {
   options = {
     programs.nixneovim.plugins.undotree = {
-      enable = mkEnableOption "Enable undotree";
+      enable = mkEnableOption "undotree";
 
       windowLayout = mkOption {
         type = types.nullOr types.int;


### PR DESCRIPTION
Fix the duplicate "enable" generated in the description when using `mkEnableOption "Enable..."`.

Basically it applies the following correction to all the plugins:

```diff
 {
   options = {
     programs.nixneovim.plugins.${name}= {
-      enable = mkEnableOption "Enable ${name}";
+      enable = mkEnableOption "${name}";
```