### PR TITLE
Changed server name for lua-language-server to lua_ls in lspconfig

### DIFF
--- a/src/plugins/_lspconfig-modules/servers.nix
+++ b/src/plugins/_lspconfig-modules/servers.nix
@@ -86,6 +86,7 @@ let
     lua-language-server = {
       languages = "Lua";
       packages = [ pkgs.lua-language-server ];
+      serverName = "lua_ls";
     };
     nil = {
       languages = "Nix";


### PR DESCRIPTION
Prevents an error in lspconfig when starting nvim as 'lua-language-server' can not be found in lspconfig. The actual name is 'lua_ls' as seen [here](https://github.com/neovim/nvim-lspconfig/blob/042aa6b27b8b8d4f4e1bd42de2037c83d676a8a0/lua/lspconfig/server_configurations/lua_ls.lua) and as seen in the [nvim-lspconfig documentation](https://github.com/neovim/nvim-lspconfig/blob/042aa6b27b8b8d4f4e1bd42de2037c83d676a8a0/doc/server_configurations.md).