### PR TITLE
filetype-plugin support

### DIFF
--- a/helpers/src/mk_lua_plugin.nix
+++ b/helpers/src/mk_lua_plugin.nix
@@ -97,6 +97,28 @@ in { name                          # name of the plugin module. Will be used in 
             (defaultModuleOptions fullDescription) // moduleOptions;
     # options = (defaultModuleOptions fullDescription) // moduleOptions;
 
+    # new
+    configOptions =
+            (defaultModuleOptions fullDescription) // moduleOptions;
+
+    # new
+    luaConfigOutput =
+      ''
+      -- config for plugin: ${name}
+      do
+        function setup()
+          ${cfg.extraLua.pre}
+          ${replaceStrings ["\n"] ["\n${indent 2}"] luaConfig}
+          ${cfg.extraLua.post}
+        end
+        success, output = pcall(setup) -- execute 'setup()' and catch any errors
+        if not success then
+          print("Error on setup for plugin: ${name}")
+          print(output)
+        end
+      end
+    '';
+
     config.programs.nixneovim =
       mkIf cfg.enable (extraNixNeovimConfig // {
         inherit extraPlugins extraPackages extraConfigVim;

--- a/nixneovim.nix
+++ b/nixneovim.nix
@@ -45,26 +45,13 @@ let
       };
     in src.plugins //
       src.environments //
-      src.colorschemes; # TODO: add the other plugins
+      src.colorschemes;
 
 
 in {
 
   imports = [
-    # manually importing './plugins' prevents infinite loop
-    # (import ./plugins { inherit pkgs lib config helpers plugins; })
-    ({
-      imports = lib.mapAttrsToList
-        (key: value: value)
-          # if key == "numb" || key == "bamboo" then
-            # lib.trace
-              # key
-              # lib.traceSeqN 1 value.options.programs.nixneovim
-                # value
-          # else
-            # value)
-        plugins;
-    })
+    { imports = lib.mapAttrsToList (key: value: value) plugins; }
   ];
 
   options = {
@@ -98,16 +85,6 @@ in {
         default = null;
         description = "The package to use for neovim.";
       };
-
-      # plugins = mkOption {
-        # type = types.attrsOf types.anything;
-        # default = {};
-      # };
-
-      # colorschems = mkOption {
-        # type = types.anything;
-        # default = {};
-      # };
 
       extraPlugins = mkOption {
         type = with types; listOf (either package pluginWithConfigType);

--- a/src/colorschemes/nord.nix
+++ b/src/colorschemes/nord.nix
@@ -1,49 +1,55 @@
-{ pkgs, config, lib }:
+{ pkgs, lib, helpers, ... }:
+
 with lib;
+
 let
+
+  name = "nord";
+  pluginUrl = "https://github.com/shaunsingh/nord.nvim";
+
   cfg = config.programs.nixneovim.colorschemes.nord;
-in
-{
-  options = {
-    programs.nixneovim.colorschemes.nord = {
-      enable = mkEnableOption "nord";
 
-      contrast = mkEnableOption
-        "Make sidebars and popup menus like nvim-tree and telescope have a different background";
+  moduleOptions = {
 
-      borders = mkEnableOption
-        "Enable the border between verticaly split windows visable";
+    contrast = mkEnableOption
+      "Make sidebars and popup menus like nvim-tree and telescope have a different background";
 
-      disable_background = mkEnableOption
-        "Disable the setting of background color so that NeoVim can use your terminal background";
+    borders = mkEnableOption
+      "Enable the border between verticaly split windows visable";
 
-      cursorline_transparent = mkEnableOption
-        "Set the cursorline transparent/visible";
+    disable_background = mkEnableOption
+      "Disable the setting of background color so that NeoVim can use your terminal background";
 
-      enable_sidebar_background = mkEnableOption
-        "Re-enables the background of the sidebar if you disabled the background of everything";
+    cursorline_transparent = mkEnableOption
+      "Set the cursorline transparent/visible";
 
-      italic = mkOption {
-        description = "enables/disables italics";
-        type = types.nullOr types.bool;
-        default = null;
-      };
+    enable_sidebar_background = mkEnableOption
+      "Re-enables the background of the sidebar if you disabled the background of everything";
+
+    italic = mkOption {
+      description = "enables/disables italics";
+      type = types.nullOr types.bool;
+      default = null;
     };
   };
 
-  config = mkIf cfg.enable {
-    programs.nixneovim = {
-      colorscheme = "nord";
-      extraPlugins = [ pkgs.vimPlugins.nord-nvim ];
+in helpers.generator.mkLuaPlugin {
+  inherit name moduleOptions pluginUrl;
+  extraPlugins = with pkgs.vimExtraPlugins; [
+    # add neovim plugin here
+    shaunsingh-nord-nvim
+  ];
+  isColorscheme = true;
+  extraConfigLua = ''
+    vim.cmd[[ colorscheme nord ]]
+  '';
 
-      globals = {
-        nord_contrast = mkIf cfg.contrast 1;
-        nord_borders = mkIf cfg.borders 1;
-        nord_disable_background = mkIf cfg.disable_background 1;
-        nord_cursoline_transparent = mkIf cfg.cursorline_transparent 1;
-        nord_enable_sidebar_background = mkIf cfg.enable_sidebar_background 1;
-        nord_italic = mkIf (cfg.italic != null) cfg.italic;
-      };
-    };
+  extraOptions = {
+    nord_contrast = mkIf cfg.contrast 1;
+    nord_borders = mkIf cfg.borders 1;
+    nord_disable_background = mkIf cfg.disable_background 1;
+    nord_cursoline_transparent = mkIf cfg.cursorline_transparent 1;
+    nord_enable_sidebar_background = mkIf cfg.enable_sidebar_background 1;
+    nord_italic = mkIf (cfg.italic != null) cfg.italic;
   };
 }


### PR DESCRIPTION
missing: 

- [ ] Support for plugins
- [ ] add all relevant options to ftplugin submodule
- [ ] decide name for option (options include: 'ftplugin' as in neovim, or  'files' as in nixvim)
- [ ] port all plugins to mkLuaPlugin so that they have the correct output