### PR TITLE
Set `outputs.nixosModules.${system}.default` to be the homeManager config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
       in {
 
         nixosModules = {
-          default = self.nixosModules.homeManager;
+          default = import ./nixneovim.nix withHomemanager;
           homeManager = import ./nixneovim.nix withHomemanager;
           homeManager-23-11 = import ./nixneovim.nix ({ state = 2311; } // withHomemanager);
           homeManager-24-05 = import ./nixneovim.nix ({ state = 2404; } // withHomemanager);


### PR DESCRIPTION
Right now, following the doc-string in the `throw` clause of `nixneovim.nixosModules.default` continues to throw the same error, because `nixneovim.nixosModules.${system}.default` defers to that same throw clause:
```text
nix-repl> (builtins.getFlake "github:nixneovim/nixneovim").outputs.nixosModules.aarch64-darwin
{
  default = «error: Breaking Change: Please specify your system like this: 'nixneovim.nixosModules.${system}.default'»;
  homeManager = «lambda @ /nix/store/lfj4aks6vg4pwszc204fnak757xa2xw9-source/nixneovim.nix:2:1»;
  homeManager-23-11 = «lambda @ /nix/store/lfj4aks6vg4pwszc204fnak757xa2xw9-source/nixneovim.nix:2:1»;
  homeManager-24-05 = «lambda @ /nix/store/lfj4aks6vg4pwszc204fnak757xa2xw9-source/nixneovim.nix:2:1»;
  nixos = «lambda @ /nix/store/lfj4aks6vg4pwszc204fnak757xa2xw9-source/nixneovim.nix:2:1»;
  nixos-23-11 = «lambda @ /nix/store/lfj4aks6vg4pwszc204fnak757xa2xw9-source/nixneovim.nix:2:1»;
  nixos-24-05 = «lambda @ /nix/store/lfj4aks6vg4pwszc204fnak757xa2xw9-source/nixneovim.nix:2:1»;
}
```

This PR _should_ remediate that, assuming that's the intended outcome.

More than happy for the outcome to be "Let's just change the throw-string instead", I just know I fought this a bunch after #122 was merged and was tearing my hair out trying to figure out what was wrong.